### PR TITLE
Can use just ollama don't need /bin/ollama

### DIFF
--- a/charts/ollama/templates/deployment.yaml
+++ b/charts/ollama/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: [ "/bin/sh", "-c", "{{- printf "echo %s | xargs -n1 /bin/ollama pull %s" (include "ollama.modelList" .) (ternary "--insecure" "" .Values.ollama.insecure)}}" ]
+                command: [ "/bin/sh", "-c", "{{- printf "echo %s | xargs -n1 ollama pull %s" (include "ollama.modelList" .) (ternary "--insecure" "" .Values.ollama.insecure)}}" ]
           {{- end }}
       volumes:
         - name: ollama-data


### PR DESCRIPTION
The default system pathing works with both the ollama/ollama container and a container using the SUSE ollma package.

The /bin breaks the container using the SUSE ollma package because it puts ollama in /user/bin