### PR TITLE
Pull in IBS built images

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -40,8 +40,8 @@ open-webui:
   ollamaUrls:
   - http://suse-private-ai-ollama.suse-private-ai.svc.cluster.local:11434 #Internally accessible ollama endpoint
   image:
-    repository: ghcr.io/open-webui/open-webui
-    tag: "latest"
+    repository: ghcr.io/brett060102/open-webui
+    tag: "v0.3.32"
     pullPolicy: "IfNotPresent"
   ingress:
     enabled: true


### PR DESCRIPTION
The IBS built ollama and open-webui containers have been pushed to ghcr.io/brett060102

This updates the helm charts to use those images.