### PR TITLE
sync with current main, don't use -test containers

### DIFF
--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -10,8 +10,8 @@ cluster:
 
 image:
   all:
-    repository: milvusdb/milvus
-    tag: v2.4.6
+    repository: ghcr.io/brett060102/milvus
+    tag: 2.4.6
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/values.yaml
+++ b/values.yaml
@@ -20,7 +20,7 @@ global:
 # Ollama subchart overrides - see the charts/ollama for additional entries
 ollama:
   image:
-    repository: ghcr.io/brett060102-test/ollama
+    repository: ghcr.io/brett060102/ollama
     pullPolicy: IfNotPresent
     tag: ""
   ingress:
@@ -29,7 +29,6 @@ ollama:
   ollama:
     models:
     - "gemma:2b"
-
     gpu:
       # -- Enable GPU integration
       enabled: false
@@ -60,8 +59,8 @@ open-webui:
   ollamaUrls:
   - http://suse-private-ai-ollama.suse-private-ai.svc.cluster.local:11434 #Internally accessible ollama endpoint
   image:
-    repository: ghcr.io/brett060102-test/open-webui
-    tag: "v0.3.32"
+    repository: ghcr.io/brett060102/open-webui
+    tag: "0.3.32"
     pullPolicy: "IfNotPresent"
   ingress:
     enabled: true


### PR DESCRIPTION
Use ghcr.io/brett060102 for milvus. ollama, and open-webui containers.
Also tag for open-webui should be 0.3.32 not v0.3.32 since our tags don't have the "v"

the main branch should be use brett060102 not brett060102-test, unti we start pulling from AppCo.